### PR TITLE
Added group by querying support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'ostruct'
 gem 'pundit'
 gem 'pg'
 gem 'pg_search'
+gem 'groupdate'
 
 group :development do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,16 @@
 PATH
   remote: .
   specs:
-    adminly (0.0.21)
+    adminly (0.0.1)
       dotenv-rails
+      groupdate
       jwt
       kaminari
       ostruct
       pg
       pg_search
       pundit
-      rails (~> 6.1.4, >= 6.1.4.1)
+      rails (>= 6.1.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -81,8 +82,10 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
-    globalid (0.5.2)
+    globalid (1.0.0)
       activesupport (>= 5.0)
+    groupdate (6.0.1)
+      activesupport (>= 5.2)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jwt (2.3.0)
@@ -153,9 +156,9 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.2)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.1.0)
     tzinfo (2.0.4)
@@ -172,6 +175,7 @@ PLATFORMS
 DEPENDENCIES
   adminly!
   dotenv-rails
+  groupdate
   jwt
   kaminari
   ostruct

--- a/adminly.gemspec
+++ b/adminly.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 6.1.4.1"
-  
+
   spec.add_dependency "dotenv-rails"
   spec.add_dependency "jwt"
   spec.add_dependency "kaminari"
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pundit"
   spec.add_dependency "pg"
   spec.add_dependency "pg_search"
+  spec.add_dependency "groupdate"
 
 end

--- a/app/controllers/concerns/adminly/scope.rb
+++ b/app/controllers/concerns/adminly/scope.rb
@@ -1,43 +1,45 @@
-module Adminly 
-  module Scope   
+module Adminly
+  module Scope
     extend ActiveSupport::Concern
 
     included do
-      
-      before_action :parse_query_params 
 
-      def adminly_scope(resources) 
-        @adminly_query.filters.each do |filter| 
-          resources = resources.where(filter) 
-        end 
-        
+      before_action :parse_query_params
+
+      def adminly_scope(resources)
+        @adminly_query.filters.each do |filter|
+          resources = resources.where(filter)
+        end
+
         if @adminly_query.keywords? and resources.respond_to?(:pg_search)
-          resources = resources.pg_search(@adminly_query.keywords) 
-        end 
+          resources = resources.pg_search(@adminly_query.keywords)
+        end
+
+        resources = resources.group(@adminly_query.group_by) if @adminly_query.group_by.present?
         resources = resources.includes(@adminly_query.includes) if @adminly_query.includes.any?
         resources = resources.order(@adminly_query.order) if @adminly_query.order?
-        resources = resources.select(@adminly_query.select) if @adminly_query.select?  
-        resources = resources.page(@adminly_query.page).per(@adminly_query.per_page)              
+        resources = resources.select(@adminly_query.select) if @adminly_query.select?
+        resources = resources.page(@adminly_query.page).per(@adminly_query.per_page)
         resources
-      end 
+      end
 
-      def adminly_meta(resources) 
+      def adminly_meta(resources)
         {
           page: @adminly_query.page,
           per_page: @adminly_query.per_page,
-          total_count: resources.total_count 
+          total_count: resources.total_count
         }
-      end 
+      end
 
       def adminly_serialize(resources, includes: nil)
         Adminly::Serializer.render(resources, includes: includes)
-      end 
-  
-      def parse_query_params
-        @adminly_query = Adminly::QueryParams.new(params)      
       end
-  
+
+      def parse_query_params
+        @adminly_query = Adminly::QueryParams.new(params)
+      end
+
     end
 
-  end 
-end 
+  end
+end

--- a/app/models/adminly/application_record.rb
+++ b/app/models/adminly/application_record.rb
@@ -1,3 +1,5 @@
+require "groupdate"
+
 module Adminly
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true

--- a/app/services/adminly/query_params.rb
+++ b/app/services/adminly/query_params.rb
@@ -111,26 +111,6 @@ module Adminly
       group_by
     end
 
-    def stats
-      stats = nil
-      if @params[:max]
-        stats = {maximum: @params[:max]}
-      end
-
-      if @params[:min]
-        stats = {minimum: @params[:min]}
-      end
-
-      if @params[:avg]
-        stats = {average: @params[:avg]}
-      end
-
-      if @params[:count]
-        stats = {count: @params[:count]}
-      end
-      stats
-    end
-
     def page
       @params[:page]&.to_i || 1
     end
@@ -152,8 +132,7 @@ module Adminly
         per_page: per_page,
         select_fields: select_fields,
         sort_by: sort_by,
-        sort_direction: sort_direction,
-        stats: stats
+        sort_direction: sort_direction
       }
     end
 
@@ -174,10 +153,6 @@ module Adminly
 
       condition = "#{field} #{operator} ?"
       [condition, value]
-    end
-
-    def stats?
-      stats ? true : false
     end
 
     def order?


### PR DESCRIPTION
Say we have a table like this in the database:

```sql
CREATE TABLE values (
  id serial primary key,
  value decimal,
  ts timestamp
);
```

Example query to get the sum of values grouped by day:

`GET /adminly/values?select=ts:day,value:sum&group_by=ts:day`

And it would roughly translate into the following SQL:

```sql
SELECT date_trunc('day', ts) AS ts, sum(value)
FROM values
GROUP BY date_trunc('day', ts)
```

It guess it would be up to the caller to know that the proper indices exist in order to perform such q query efficiently.