### PR TITLE
Delete Adminly constant if defined

### DIFF
--- a/app/models/adminly/record.rb
+++ b/app/models/adminly/record.rb
@@ -9,11 +9,14 @@ module Adminly
       # Create an Abstract Active Record class and
       # assign the table name from params
       class_name = table_name.singularize.capitalize
+      
+      # Reset the constant to prevent ActiveRecord update errors
       if Object.const_defined? class_name
-        klass = class_name.constantize
-      else
-        klass = Object.const_set class_name, Class.new(Adminly::Record)
-      end
+        Object.send(:remove_const, class_name)        
+      end 
+      
+      klass = Object.const_set class_name, Class.new(Adminly::Record)
+      
       #klass.table_name = table_name.downcase.pluralize
       klass.table_name = table_name.downcase
 


### PR DESCRIPTION
Reset the Adminly ActiveRecord model per query to prevent issue when updating models previously defined with associations. 