### PR TITLE
Add permitted params to controller

### DIFF
--- a/app/controllers/adminly/api_controller.rb
+++ b/app/controllers/adminly/api_controller.rb
@@ -108,7 +108,9 @@ module Adminly
     end
 
     def adminly_params
-      params.require(params[:table_name]).permit!
+      params
+        .require(params[:table_name])
+        .permit(@adminly_record.table_columns)
     end
 
     def sql_query_params

--- a/app/models/adminly/record.rb
+++ b/app/models/adminly/record.rb
@@ -74,7 +74,7 @@ module Adminly
     def self.build_pg_search_scope
       self.pg_search_scope(
         :pg_search,
-        against: self.searchable_fields,
+        against: self.table_columns,
         using: {
           tsearch: {
             prefix: true,
@@ -88,7 +88,7 @@ module Adminly
       name && name.singularize == name
     end
 
-    def self.searchable_fields
+    def self.table_columns
       return [] if self.table_name.nil?
       self.columns.map(&:name)
     end


### PR DESCRIPTION
- Add method `table_columns` to Adminly::Record
- Use table_columns for searchable attributes and for permitted params