### PR TITLE
Support a new name parameter with association queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,40 +208,31 @@ supported are belongs_to, has_many, and has_and_belongs_to_many.
 To include a belongs_to table association, use the belongs_to query param:
 
 ```
-GET /adminly/api/books?belongs_to=<table_name>:<foreign_key>
+GET /adminly/api/books?belongs_to=<name>:<foreign_table>:<foreign_key>
 ```
+
+The `name` is a new field that will be included and part of the response during serialization, 
+the `foreign_table` is the foreign table, and `foreign_key` is the foreign key necessary to 
+join the tables. 
+
 Example: 
 ```
-GET /adminly/api/books?belongs_to=authors:author_id
+GET /adminly/api/books?belongs_to=author:authors:author_id
 ```
 
 If the foreign key is omitted, Adminly will guess the foreign key field using Rails conventions, namely 
 that the foreign key is the singular form of the table name followed by `_id`
 
 #### Has many 
-
 To include a has_many table association, use the `has_many` parameter:
 
 ```
-GET /adminly/api/books?has_many=<table_name>:<foreign_key> 
+GET /adminly/api/books?has_many=<name>:<foreign_table>:<foreign_key> 
 ```
 
 Example
 ```
-GET /adminly/api/books?has_many=reviews:book_id 
-```
-
-#### Has and belongs to many 
-
-There is also some limited-support for has_and_belongs_to_many associations using a join table with the `habtm` parameter:
-
-```
-GET /adminly/api/books?has_many=<table_name>:<join_table> 
-```
-
-Example
-```
-GET /adminly/api/books?habtm=readers:books_readers
+GET /adminly/api/books?has_many=reviews:book_reviews:book_id 
 ```
 
 ### Create

--- a/app/models/adminly/record.rb
+++ b/app/models/adminly/record.rb
@@ -50,23 +50,23 @@ module Adminly
     def self.build_associations(belongs_to: nil, has_many: nil,  habtm: nil)
 
       belongs_to&.each do |table|
-        table_name, foreign_key = table.split(":")
+        name, table_name, foreign_key = table.split(":")
         foreign_key = table_name.singularize.downcase + '_id' if foreign_key.nil?
         klass = Adminly::Record.to_active_record(table_name)
-        self.belongs_to table_name.singularize.downcase.to_sym, class_name: klass.name, foreign_key: foreign_key, optional: true
+        self.belongs_to name.to_sym, class_name: klass.name, foreign_key: foreign_key, optional: true
       end
 
       has_many&.each do |table|
-        table_name, foreign_key = table.split(":")
+        name, table_name, foreign_key = table.split(":")
         foreign_key = self.table_name.singularize.downcase + '_id' if foreign_key.nil?
         klass = Adminly::Record.to_active_record(table_name)
-        self.has_many table_name.downcase.to_sym, class_name: klass.name, foreign_key: foreign_key
+        self.has_many name.to_sym, class_name: klass.name, foreign_key: foreign_key
       end
 
       habtm&.each do |table|
-        table_name, join_table = table.split(":")
+        name, table_name, join_table = table.split(":")
         klass = Adminly::Record.to_active_record(table_name)
-        self.has_and_belongs_to_many table_name.downcase.to_sym, class_name: klass.name, join_table: join_table
+        self.has_and_belongs_to_many name.to_sym, class_name: klass.name, join_table: join_table
       end
 
     end

--- a/app/services/adminly/query_params.rb
+++ b/app/services/adminly/query_params.rb
@@ -101,11 +101,11 @@ module Adminly
     end
 
     def includes
-      sanitize = proc { |rel| rel.split(":").first }
+      field_name = proc { |rel| rel.split(":").first }
 
-      includes_bt = belongs_to&.map(&sanitize)&.map(&:singularize)
-      includes_hm = has_many&.map(&sanitize)
-      includes_habtm = habtm&.map(&sanitize)
+      includes_bt = belongs_to&.map(&field_name)
+      includes_hm = has_many&.map(&field_name)
+      includes_habtm = habtm&.map(&field_name)
       [includes_bt, includes_hm, includes_habtm].flatten.compact
     end
 

--- a/app/services/adminly/serializer.rb
+++ b/app/services/adminly/serializer.rb
@@ -2,7 +2,7 @@ module Adminly
   module Serializer 
 
     def self.render(current_scope, includes: [])             
-      current_scope.as_json(include: includes&.map(&:downcase))
+      current_scope.as_json(include: includes)
     end 
 
   end 


### PR DESCRIPTION
All association queries now require a 3rd parameter, which is the name of the association. This name is used during the serialization process and helps resolve an issue when there are two or more references to the same table which caused a naming conflict earlier. 

The new query syntax is:
`belongs_to=<name>:<foreign_table>:<foreign_key>`
`has_many=<name>:<foreign_table>:<foreign_key>`
`habtm=<name>:<foreign_table>:<join_table>`

